### PR TITLE
fix link names in tagcloud with useheading

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -99,9 +99,10 @@ class syntax_plugin_cloud extends DokuWiki_Syntax_Plugin {
                         $link = wl($id);
                         if($conf['useheading']) {
                             $name = p_get_first_heading($id, false);
-                        } else {
-                            $name = $word;
-                        }
+                            if (empty($name)) {
+                                $name = $word;
+                            }
+			}
                     } else {
                         $link = wl($id, array('do'=>'showtag', 'tag'=>$word));
                     }


### PR DESCRIPTION
When a tag page has no first heading, the tag link ends up empty in the
tag cloud. Make it fallback to the tag name.
